### PR TITLE
Create single-file HTML version of Quake Map Flipper

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,29 @@ I told it the results were good and it gave me another code block.
 
 I tested it using the Quake 1 E1M1, E1M2, and DM1. I did not compile maps beyond that. If you do, please report back!
 
-# Useage
+# Usage
 
-run the python script as you would any other. (python is obviously required)
-Pops up with a GUI. It asks for an input file, output file, and has check boxes for which axis you want to flip. Z makes it upside down, which is generally unplayable. 
+There are two versions of the tool available.
+
+## Python Version (Legacy)
+
+To use the original Python version, run one of the `QuakeMapFlipperV*.py` scripts with Python.
+```
+python QuakeMapFlipperV4.py
+```
+This will open a simple GUI. It asks for an input file, an output file, and has check boxes for which axis you want to flip. Z makes the map upside down, which is generally unplayable. This version may not support all `.map` formats.
+
+## HTML Version (Recommended)
+
+A new, more robust version is available as a single HTML file: `index.html`.
+
+**To use it, simply open `index.html` in a modern web browser.**
+
+This version offers several advantages:
+- **No Python required:** Runs entirely in your browser.
+- **Improved UI:** Features a progress bar and a detailed log so you can see what's happening, preventing the browser from freezing on large files.
+- **Broader Compatibility:** Supports both standard and modern Valve 220 texture formats in `.map` files.
+- **Easy to use:** Just select your file, choose the axes to flip, and click the "Flip Map" button. A download button will appear with your converted file.
 
 # License
 

--- a/index.html
+++ b/index.html
@@ -1,0 +1,467 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Quake .map Flipper</title>
+    <style>
+        body {
+            font-family: sans-serif;
+            background-color: #f0f0f0;
+            color: #333;
+            max-width: 600px;
+            margin: 20px auto;
+            padding: 20px;
+            border-radius: 8px;
+            box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+        }
+        h1 {
+            text-align: center;
+            color: #5d4037;
+        }
+        .control-group {
+            background-color: #fff;
+            border: 1px solid #ddd;
+            padding: 15px;
+            margin-bottom: 15px;
+            border-radius: 4px;
+        }
+        label {
+            display: block;
+            margin-bottom: 5px;
+            font-weight: bold;
+        }
+        input[type="file"] {
+            width: 100%;
+            padding: 8px;
+            box-sizing: border-box;
+        }
+        .axis-selection {
+            display: flex;
+            gap: 20px;
+            margin-top: 10px;
+        }
+        button {
+            display: block;
+            width: 100%;
+            padding: 10px;
+            font-size: 16px;
+            color: #fff;
+            background-color: #795548;
+            border: none;
+            border-radius: 4px;
+            cursor: pointer;
+            margin-top: 10px;
+        }
+        button:hover {
+            background-color: #5d4037;
+        }
+        button:disabled {
+            background-color: #a1887f;
+            cursor: not-allowed;
+        }
+        #status {
+            margin-top: 15px;
+            padding: 10px;
+            background-color: #e8f5e9;
+            border: 1px solid #c8e6c9;
+            border-radius: 4px;
+            text-align: center;
+        }
+        #progress-container {
+            margin-top: 15px;
+        }
+        progress {
+            width: 100%;
+            height: 20px;
+        }
+        #log-box {
+            width: 100%;
+            height: 150px;
+            margin-top: 10px;
+            font-family: monospace;
+            font-size: 12px;
+            background-color: #222;
+            color: #0f0;
+            border: 1px solid #444;
+            border-radius: 4px;
+            padding: 5px;
+            box-sizing: border-box;
+        }
+        .button-link {
+            display: inline-block;
+            width: 100%;
+            padding: 10px;
+            font-size: 16px;
+            color: #fff;
+            background-color: #795548;
+            border: none;
+            border-radius: 4px;
+            cursor: pointer;
+            margin-top: 10px;
+            text-decoration: none;
+            text-align: center;
+            box-sizing: border-box;
+        }
+        .button-link:hover {
+            background-color: #5d4037;
+        }
+        .button-link.disabled {
+            background-color: #a1887f;
+            cursor: not-allowed;
+            pointer-events: none;
+        }
+    </style>
+</head>
+<body>
+    <h1>Quake .map Flipper</h1>
+    <fieldset id="main-controls">
+        <div class="control-group">
+            <label for="mapFile">1. Select a .map file:</label>
+            <input type="file" id="mapFile" accept=".map">
+        </div>
+
+        <div class="control-group">
+            <label>2. Choose axis to flip:</label>
+            <div class="axis-selection">
+                <label for="flipX"><input type="checkbox" id="flipX"> Flip X</label>
+                <label for="flipY"><input type="checkbox" id="flipY"> Flip Y</label>
+                <label for="flipZ"><input type="checkbox" id="flipZ"> Flip Z</label>
+            </div>
+        </div>
+    </fieldset>
+
+    <button id="processBtn">Flip Map</button>
+
+    <div id="progress-container" style="display: none;">
+        <p id="status">Ready.</p>
+        <progress id="progressBar" value="0" max="100"></progress>
+        <textarea id="log-box" readonly></textarea>
+    </div>
+
+    <a id="downloadLink" class="button-link disabled" href="#" download>Download Flipped .map</a>
+
+    <script>
+        // --- Regular Expressions ---
+        const entityOriginRe = /^\s*("origin")\s*("(-?\d+\.?\d*)\s+(-?\d+\.?\d*)\s+(-?\d+\.?\d*)")\s*$/;
+        const entityAngleRe = /^\s*("angle")\s*("(-?\d+)")\s*$/;
+        const entityAnglesRe = /^\s*("angles")\s*("(-?\d+\.?\d*)\s+(-?\d+\.?\d*)\s+(-?\d+\.?\d*)")\s*$/;
+        const entityClassnameRe = /^\s*("classname")\s*("([^"]*)")\s*$/;
+        const entityMessageRe = /^\s*("message")\s*("([^"]*)")\s*$/;
+        const entityMapRe = /^\s*("map")\s*("([^"]*)")\s*$/;
+        const planeReStandard = /^\s*\(\s*(-?\d+\.?\d*)\s+(-?\d+\.?\d*)\s+(-?\d+\.?\d*)\s*\)\s*\(\s*(-?\d+\.?\d*)\s+(-?\d+\.?\d*)\s+(-?\d+\.?\d*)\s*\)\s*\(\s*(-?\d+\.?\d*)\s+(-?\d+\.?\d*)\s+(-?\d+\.?\d*)\s*\)\s*([^\s]+)\s+(-?\d+\.?\d*)\s+(-?\d+\.?\d*)\s+(-?\d+\.?\d*)\s+(-?\d+\.?\d*)\s+(-?\d+\.?\d*)\s*$/;
+        const planeReValve = /^\s*\(\s*(-?\d+\.?\d*)\s+(-?\d+\.?\d*)\s+(-?\d+\.?\d*)\s*\)\s*\(\s*(-?\d+\.?\d*)\s+(-?\d+\.?\d*)\s+(-?\d+\.?\d*)\s*\)\s*\(\s*(-?\d+\.?\d*)\s+(-?\d+\.?\d*)\s+(-?\d+\.?\d*)\s*\)\s*([^\s]+)\s+\[\s*(-?\d+\.?\d*)\s+(-?\d+\.?\d*)\s+(-?\d+\.?\d*)\s+(-?\d+\.?\d*)\s*\]\s*\[\s*(-?\d+\.?\d*)\s+(-?\d+\.?\d*)\s+(-?\d+\.?\d*)\s+(-?\d+\.?\d*)\s*\]\s+(-?\d+\.?\d*)\s+(-?\d+\.?\d*)\s+(-?\d+\.?\d*)\s*$/;
+
+        // --- Helper Functions ---
+        function formatNum(val) {
+            const fVal = parseFloat(val);
+            if (isNaN(fVal)) return val;
+            if (fVal === parseInt(fVal, 10)) {
+                return String(parseInt(fVal, 10));
+            }
+            return fVal.toFixed(4).replace(/\.?0+$/, '');
+        }
+
+        function normalizeAngle(angle) {
+            return (angle % 360 + 360) % 360; // Ensure positive result
+        }
+
+        // --- Core Processing Function (Async) ---
+        async function processMapFileAsync(mapContent, flipX, flipY, flipZ, { onProgress, onLog }) {
+            const lines = mapContent.replace(/\r\n/g, '\n').split('\n');
+            let output = [];
+            let braceLevel = 0;
+            let inBrush = false;
+            let currentClassname = null;
+            const flipAxisCount = (flipX ? 1 : 0) + (flipY ? 1 : 0) + (flipZ ? 1 : 0);
+            const reverseWinding = (flipAxisCount % 2 !== 0);
+
+            const totalLines = lines.length;
+            const chunkSize = 1000; // Process 1000 lines at a time
+
+            onLog('Starting map processing...');
+
+            for (let i = 0; i < totalLines; i++) {
+                const line = lines[i];
+                const strippedLine = line.trim();
+                let processedLine = line;
+
+                if (!strippedLine || strippedLine.startsWith("//")) {
+                    output.push(processedLine);
+                    continue;
+                }
+
+                if (strippedLine === "{") {
+                    braceLevel++;
+                    if (braceLevel === 1) {
+                        currentClassname = null;
+                        onLog(`Entering entity definition at line ${i + 1}`);
+                    }
+                    if (braceLevel === 2) inBrush = true;
+                    output.push(processedLine);
+                    continue;
+                } else if (strippedLine === "}") {
+                    if (braceLevel === 2) inBrush = false;
+                    if (braceLevel === 1) onLog(`Exiting entity definition at line ${i + 1}`);
+                    braceLevel = Math.max(0, braceLevel - 1);
+                    if (braceLevel === 0) currentClassname = null;
+                    output.push(processedLine);
+                    continue;
+                }
+
+                let lineProcessed = false;
+
+                if (!inBrush && braceLevel === 1) {
+                    if (currentClassname === null) {
+                        const classnameMatch = line.match(entityClassnameRe);
+                        if (classnameMatch) currentClassname = classnameMatch[3];
+                    }
+                    if (currentClassname === "worldspawn") {
+                        const messageMatch = line.match(entityMessageRe);
+                        if (messageMatch) {
+                            const key = messageMatch[1];
+                            const value = messageMatch[3];
+                            const newValue = value + " Flipped";
+                            processedLine = `\t${key} "${newValue}"`;
+                            lineProcessed = true;
+                        }
+                    } else if (currentClassname === "trigger_changelevel") {
+                        const mapMatch = line.match(entityMapRe);
+                        if (mapMatch) {
+                            const key = mapMatch[1];
+                            const value = mapMatch[3];
+                            const newValue = value + "_flipped";
+                            processedLine = `\t${key} "${newValue}"`;
+                            lineProcessed = true;
+                        }
+                    }
+
+                    if (!lineProcessed) {
+                        const originMatch = line.match(entityOriginRe);
+                        if (originMatch) {
+                            const key = originMatch[1];
+                            let [x, y, z] = [parseFloat(originMatch[3]), parseFloat(originMatch[4]), parseFloat(originMatch[5])];
+                            const newX = flipX ? -x : x;
+                            const newY = flipY ? -y : y;
+                            const newZ = flipZ ? -z : z;
+                            processedLine = `\t${key} "${formatNum(newX)} ${formatNum(newY)} ${formatNum(newZ)}"`;
+                            lineProcessed = true;
+                        }
+                    }
+
+                    if (!lineProcessed) {
+                        const angleMatch = line.match(entityAngleRe);
+                        if (angleMatch) {
+                            const key = angleMatch[1];
+                            const currentAngle = parseInt(angleMatch[3], 10);
+                            let newAngle = parseFloat(currentAngle);
+                            if (currentAngle < 0) { // Up/Down
+                                if (flipZ) newAngle = currentAngle === -2 ? -1.0 : -2.0;
+                            } else { // Direction/Facing
+                                if (flipX) newAngle = 180.0 - newAngle;
+                                if (flipY) newAngle = -newAngle;
+                                newAngle = normalizeAngle(newAngle);
+                            }
+                            processedLine = `\t${key} "${Math.round(newAngle)}"`;
+                            lineProcessed = true;
+                        }
+                    }
+
+                    if (!lineProcessed) {
+                        const anglesMatch = line.match(entityAnglesRe);
+                        if (anglesMatch) {
+                            const key = anglesMatch[1];
+                            let [pitch, yaw, roll] = [parseFloat(anglesMatch[3]), parseFloat(anglesMatch[4]), parseFloat(anglesMatch[5])];
+                            let [newPitch, newYaw, newRoll] = [pitch, yaw, roll];
+                            if (flipX) { newYaw = 180.0 - newYaw; newRoll = -newRoll; }
+                            if (flipY) { newYaw = -newYaw; newRoll = -newRoll; }
+                            if (flipZ) { newPitch = -newPitch; }
+                            newYaw = normalizeAngle(newYaw);
+                            processedLine = `\t${key} "${formatNum(newPitch)} ${formatNum(newYaw)} ${formatNum(newRoll)}"`;
+                            lineProcessed = true;
+                        }
+                    }
+                } else if (inBrush && braceLevel === 2) {
+                    let valveMatch = line.match(planeReValve);
+                    let standardMatch = !valveMatch ? line.match(planeReStandard) : null;
+
+                    if (valveMatch) {
+                        const groups = valveMatch.slice(1);
+                        const v = groups.slice(0, 9).map(parseFloat);
+                        const texName = groups[9];
+                        const texVecs = groups.slice(10, 18).map(parseFloat);
+                        const texParams = groups.slice(18).map(parseFloat);
+
+                        const [ v1x, v1y, v1z, v2x, v2y, v2z, v3x, v3y, v3z ] = v;
+                        const [ uX, uY, uZ, uOff, vX, vY, vZ, vOff ] = texVecs;
+                        const [ rot, scaleX, scaleY ] = texParams;
+
+                        const nv1x = flipX ? -v1x : v1x, nv1y = flipY ? -v1y : v1y, nv1z = flipZ ? -v1z : v1z;
+                        const nv2x = flipX ? -v2x : v2x, nv2y = flipY ? -v2y : v2y, nv2z = flipZ ? -v2z : v2z;
+                        const nv3x = flipX ? -v3x : v3x, nv3y = flipY ? -v3y : v3y, nv3z = flipZ ? -v3z : v3z;
+
+                        const fmtV = (x,y,z) => `${formatNum(x)} ${formatNum(y)} ${formatNum(z)}`;
+                        const v1Str = fmtV(nv1x, nv1y, nv1z);
+                        const v2Str = fmtV(nv2x, nv2y, nv2z);
+                        const v3Str = fmtV(nv3x, nv3y, nv3z);
+
+                        // This is a simplification. Proper texture flipping for Valve 220 is more complex,
+                        // but we are replicating the original script's heuristic.
+                        const newUOff = flipX ? -uOff : uOff;
+                        const newVOff = flipY ? -vOff : vOff;
+                        const newRot = -rot;
+
+                        const texInfoStr = `${texName} [ ${formatNum(uX)} ${formatNum(uY)} ${formatNum(uZ)} ${formatNum(newUOff)} ] [ ${formatNum(vX)} ${formatNum(vY)} ${formatNum(vZ)} ${formatNum(newVOff)} ] ${formatNum(newRot)} ${formatNum(scaleX)} ${formatNum(scaleY)}`;
+
+                        if (reverseWinding) {
+                            processedLine = ` ( ${v1Str} ) ( ${v3Str} ) ( ${v2Str} ) ${texInfoStr}`;
+                        } else {
+                            processedLine = ` ( ${v1Str} ) ( ${v2Str} ) ( ${v3Str} ) ${texInfoStr}`;
+                        }
+                        lineProcessed = true;
+
+                    } else if (standardMatch) {
+                        const groups = standardMatch.slice(1);
+                        const v = groups.slice(0, 9).map(parseFloat);
+                        const texName = groups[9];
+                        const texParams = groups.slice(10).map(parseFloat);
+
+                        const [ v1x, v1y, v1z, v2x, v2y, v2z, v3x, v3y, v3z ] = v;
+                        const [ offX, offY, rot, scaleX, scaleY ] = texParams;
+
+                        const nv1x = flipX ? -v1x : v1x, nv1y = flipY ? -v1y : v1y, nv1z = flipZ ? -v1z : v1z;
+                        const nv2x = flipX ? -v2x : v2x, nv2y = flipY ? -v2y : v2y, nv2z = flipZ ? -v2z : v2z;
+                        const nv3x = flipX ? -v3x : v3x, nv3y = flipY ? -v3y : v3y, nv3z = flipZ ? -v3z : v3z;
+
+                        const fmtV = (x,y,z) => `${formatNum(x)} ${formatNum(y)} ${formatNum(z)}`;
+                        const v1Str = fmtV(nv1x, nv1y, nv1z);
+                        const v2Str = fmtV(nv2x, nv2y, nv2z);
+                        const v3Str = fmtV(nv3x, nv3y, nv3z);
+
+                        const newRot = -rot;
+                        const newOffX = flipX ? -offX : offX;
+                        const newOffY = flipY ? -offY : offY;
+
+                        const texInfoStr = `${texName} ${formatNum(newOffX)} ${formatNum(newOffY)} ${formatNum(newRot)} ${formatNum(scaleX)} ${formatNum(scaleY)}`;
+
+                        if (reverseWinding) {
+                            processedLine = ` ( ${v1Str} ) ( ${v3Str} ) ( ${v2Str} ) ${texInfoStr}`;
+                        } else {
+                            processedLine = ` ( ${v1Str} ) ( ${v2Str} ) ( ${v3Str} ) ${texInfoStr}`;
+                        }
+                        lineProcessed = true;
+                    }
+                }
+                output.push(processedLine);
+
+                // Yield to main thread every chunk
+                if (i % chunkSize === 0) {
+                    const progress = (i / totalLines) * 100;
+                    onProgress(progress);
+                    await new Promise(resolve => setTimeout(resolve, 0));
+                }
+            }
+            onProgress(100);
+            onLog('Processing complete.');
+            return output.join('\n');
+        }
+
+        // --- Event Listeners ---
+        document.addEventListener('DOMContentLoaded', () => {
+            const mainControls = document.getElementById('main-controls');
+            const mapFileInput = document.getElementById('mapFile');
+            const flipXInput = document.getElementById('flipX');
+            const flipYInput = document.getElementById('flipY');
+            const flipZInput = document.getElementById('flipZ');
+            const processBtn = document.getElementById('processBtn');
+            const progressContainer = document.getElementById('progress-container');
+            const statusP = document.getElementById('status');
+            const progressBar = document.getElementById('progressBar');
+            const logBox = document.getElementById('log-box');
+            const downloadLink = document.getElementById('downloadLink');
+
+            let currentObjectURL = null;
+
+            const log = (message) => {
+                logBox.value += `[${new Date().toLocaleTimeString()}] ${message}\n`;
+                logBox.scrollTop = logBox.scrollHeight;
+            };
+
+            const setProgress = (percentage) => {
+                progressBar.value = percentage;
+            };
+
+            processBtn.addEventListener('click', async () => {
+                const file = mapFileInput.files[0];
+                const flipX = flipXInput.checked;
+                const flipY = flipYInput.checked;
+                const flipZ = flipZInput.checked;
+
+                if (!file) {
+                    alert('Error: Please select a .map file first.');
+                    return;
+                }
+                if (!flipX && !flipY && !flipZ) {
+                    alert('Error: Please select at least one axis to flip.');
+                    return;
+                }
+
+                // Reset UI
+                mainControls.disabled = true;
+                processBtn.disabled = true;
+                processBtn.textContent = 'Processing...';
+                progressContainer.style.display = 'block';
+                logBox.value = '';
+                downloadLink.classList.add('disabled');
+                if (currentObjectURL) {
+                    URL.revokeObjectURL(currentObjectURL);
+                }
+
+                const reader = new FileReader();
+                reader.onload = async (event) => {
+                    try {
+                        const mapContent = event.target.result;
+                        statusP.textContent = `Processing ${file.name}...`;
+
+                        const flippedContent = await processMapFileAsync(mapContent, flipX, flipY, flipZ, { onProgress: setProgress, onLog: log });
+
+                        const blob = new Blob([flippedContent], { type: 'text/plain' });
+                        currentObjectURL = URL.createObjectURL(blob);
+
+                        const originalFilename = file.name;
+                        const base = originalFilename.substring(0, originalFilename.lastIndexOf('.')) || originalFilename;
+                        const ext = originalFilename.substring(originalFilename.lastIndexOf('.'));
+                        const newFilename = `${base}_flipped${ext}`;
+
+                        downloadLink.href = currentObjectURL;
+                        downloadLink.download = newFilename;
+                        downloadLink.classList.remove('disabled');
+
+                        statusP.textContent = `Success! Flipped map is ready for download.`;
+                        log('File ready for download.');
+
+                    } catch (e) {
+                        statusP.textContent = `An unexpected error occurred: ${e.message}`;
+                        log(`ERROR: ${e.message}`);
+                        console.error(e);
+                    } finally {
+                        mainControls.disabled = false;
+                        processBtn.disabled = false;
+                        processBtn.textContent = 'Flip Map';
+                    }
+                };
+
+                reader.onerror = () => {
+                    statusP.textContent = 'Error reading the file.';
+                    log('FATAL: Error reading the file.');
+                    mainControls.disabled = false;
+                    processBtn.disabled = false;
+                    processBtn.textContent = 'Flip Map';
+                };
+
+                reader.readAsText(file);
+            });
+        });
+    </script>
+</body>
+</html>


### PR DESCRIPTION
This commit introduces a single-file HTML/JavaScript version of the Quake Map Flipper tool, `index.html`.

This new version provides several improvements over the original Python script:
- It runs entirely in the browser with no dependencies.
- The UI is more responsive, featuring a progress bar and a log to provide feedback during processing of large files.
- It correctly parses both standard and modern Valve 220 map formats.
- A bug that corrupted texture names starting with numbers has been fixed.

The README.md has also been updated to document this new version and how to use it.